### PR TITLE
Upgraded @uncharted\strippets and @uncharted\thumbnails

### DIFF
--- a/lib/@uncharted/strippets/example/uncharted.strippets.js
+++ b/lib/@uncharted/strippets/example/uncharted.strippets.js
@@ -2301,9 +2301,24 @@ Outline.prototype.resetState = function() {
 Outline.prototype.showEntities = function (display) {
     var s = this;
     if (s.feature && s.feature.$outlineEntityContainer) {
-        s.feature.$outlineEntityContainer.css({
-            display: display,
-        });
+
+        if(display === 'show') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'inline-block',
+                width: '100%',
+            });
+        } else if (display === 'hide') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'none',
+            });
+        } else {
+            s.feature.$outlineEntityContainer.css({
+                display: '',
+                width: '',
+            });
+        }
+
+
     }
 };
 
@@ -2315,7 +2330,7 @@ Outline.prototype.openReadingMode = function() {
     var s = this;
     var promises = [];
 
-    s.showEntities('none');
+    s.showEntities('hide');
 
     promises.push(s.reader.open().then(function() {
         if (!s.readerData) {
@@ -2339,7 +2354,7 @@ Outline.prototype.openReadingMode = function() {
     );
 
     return Promise.all(promises).then(function() {
-        s.showEntities('block');
+        s.showEntities('show');
     });
 };
 
@@ -2365,7 +2380,7 @@ Outline.prototype.loadReadingModeContent = function() {
 Outline.prototype.closeReadingMode = function() {
     var s = this;
     var promises = [];
-    s.showEntities('none');
+    s.showEntities('hide');
     if (s.styles.outlineItem.normal) {
         promises.push(s.$outline.velocity({
             'margin-right': s.styles.outlineItem.normal.getPropertyValue('margin-right'),
@@ -2373,9 +2388,10 @@ Outline.prototype.closeReadingMode = function() {
         }));
     }
     promises.push(s.reader.hide());
-    return Promise.all(promises).then(function () {
-        s.showEntities('block');
+	promises.push(function () {
+        s.showEntities('clear');
     });
+    return Promise.all(promises);
 };
 
 /**
@@ -2480,7 +2496,7 @@ Outline.prototype.getTransitionSizes = function(transitionToState) {
         if (toState === 'readingmode') {
             transitionCompleteSize = {
                 height: s.$outline.height(),
-                width: Reader.prototype.getActualReaderWidth(s.Settings.reader, s.$outline)
+                width: Reader.prototype.getActualReaderWidth.call(s.reader, s.Settings.reader, s.$outline)
                 + s.Settings.maincontent.minimizedWidth
                 + ((s.Settings.sidebarEnabled && s.sidebar) ? s.Settings.sidebar.minimizedWidth : 0),
             };

--- a/lib/@uncharted/strippets/package.json
+++ b/lib/@uncharted/strippets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uncharted/strippets",
-  "version": "0.4.40",
+  "version": "0.4.42",
   "description": "Uncharted Software Inc. Outlines visual component",
   "main": "src/index.js",
   "scripts": {
@@ -29,13 +29,13 @@
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.1.1",
     "karma-phantomjs-launcher": "^1.0.4",
-    "karma-sinon-chai": "^1.1.0",
+    "karma-sinon-chai": "^1.3.1",
     "karma-tamtam-bamboo-reporter": "^1.0.1",
     "mocha": "^2.3.3",
     "phantomjs-prebuilt": "^2.1.3",
     "proxyquireify": "^3.0.0",
     "run-sequence": "^1.1.5",
-    "sinon": "^1.17.3",
+    "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0",
     "through2": "^2.0.0",
     "vinyl-source-stream": "^1.1.0"

--- a/lib/@uncharted/strippets/src/strippets.outline.js
+++ b/lib/@uncharted/strippets/src/strippets.outline.js
@@ -558,9 +558,24 @@ Outline.prototype.resetState = function() {
 Outline.prototype.showEntities = function (display) {
     var s = this;
     if (s.feature && s.feature.$outlineEntityContainer) {
-        s.feature.$outlineEntityContainer.css({
-            display: display,
-        });
+
+        if(display === 'show') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'inline-block',
+                width: '100%',
+            });
+        } else if (display === 'hide') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'none',
+            });
+        } else {
+            s.feature.$outlineEntityContainer.css({
+                display: '',
+                width: '',
+            });
+        }
+
+
     }
 };
 
@@ -572,7 +587,7 @@ Outline.prototype.openReadingMode = function() {
     var s = this;
     var promises = [];
 
-    s.showEntities('none');
+    s.showEntities('hide');
 
     promises.push(s.reader.open().then(function() {
         if (!s.readerData) {
@@ -596,7 +611,7 @@ Outline.prototype.openReadingMode = function() {
     );
 
     return Promise.all(promises).then(function() {
-        s.showEntities('block');
+        s.showEntities('show');
     });
 };
 
@@ -622,7 +637,7 @@ Outline.prototype.loadReadingModeContent = function() {
 Outline.prototype.closeReadingMode = function() {
     var s = this;
     var promises = [];
-    s.showEntities('none');
+    s.showEntities('hide');
     if (s.styles.outlineItem.normal) {
         promises.push(s.$outline.velocity({
             'margin-right': s.styles.outlineItem.normal.getPropertyValue('margin-right'),
@@ -630,9 +645,10 @@ Outline.prototype.closeReadingMode = function() {
         }));
     }
     promises.push(s.reader.hide());
-    return Promise.all(promises).then(function () {
-        s.showEntities('block');
+	promises.push(function () {
+        s.showEntities('clear');
     });
+    return Promise.all(promises);
 };
 
 /**
@@ -737,7 +753,7 @@ Outline.prototype.getTransitionSizes = function(transitionToState) {
         if (toState === 'readingmode') {
             transitionCompleteSize = {
                 height: s.$outline.height(),
-                width: Reader.prototype.getActualReaderWidth(s.Settings.reader, s.$outline)
+                width: Reader.prototype.getActualReaderWidth.call(s.reader, s.Settings.reader, s.$outline)
                 + s.Settings.maincontent.minimizedWidth
                 + ((s.Settings.sidebarEnabled && s.sidebar) ? s.Settings.sidebar.minimizedWidth : 0),
             };

--- a/lib/@uncharted/thumbnails/example/uncharted.thumbnails.js
+++ b/lib/@uncharted/thumbnails/example/uncharted.thumbnails.js
@@ -5313,9 +5313,24 @@ Outline.prototype.resetState = function() {
 Outline.prototype.showEntities = function (display) {
     var s = this;
     if (s.feature && s.feature.$outlineEntityContainer) {
-        s.feature.$outlineEntityContainer.css({
-            display: display,
-        });
+
+        if(display === 'show') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'inline-block',
+                width: '100%',
+            });
+        } else if (display === 'hide') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'none',
+            });
+        } else {
+            s.feature.$outlineEntityContainer.css({
+                display: '',
+                width: '',
+            });
+        }
+
+
     }
 };
 
@@ -5327,7 +5342,7 @@ Outline.prototype.openReadingMode = function() {
     var s = this;
     var promises = [];
 
-    s.showEntities('none');
+    s.showEntities('hide');
 
     promises.push(s.reader.open().then(function() {
         if (!s.readerData) {
@@ -5351,7 +5366,7 @@ Outline.prototype.openReadingMode = function() {
     );
 
     return Promise.all(promises).then(function() {
-        s.showEntities('block');
+        s.showEntities('show');
     });
 };
 
@@ -5377,7 +5392,7 @@ Outline.prototype.loadReadingModeContent = function() {
 Outline.prototype.closeReadingMode = function() {
     var s = this;
     var promises = [];
-    s.showEntities('none');
+    s.showEntities('hide');
     if (s.styles.outlineItem.normal) {
         promises.push(s.$outline.velocity({
             'margin-right': s.styles.outlineItem.normal.getPropertyValue('margin-right'),
@@ -5385,9 +5400,10 @@ Outline.prototype.closeReadingMode = function() {
         }));
     }
     promises.push(s.reader.hide());
-    return Promise.all(promises).then(function () {
-        s.showEntities('block');
+	promises.push(function () {
+        s.showEntities('clear');
     });
+    return Promise.all(promises);
 };
 
 /**
@@ -5492,7 +5508,7 @@ Outline.prototype.getTransitionSizes = function(transitionToState) {
         if (toState === 'readingmode') {
             transitionCompleteSize = {
                 height: s.$outline.height(),
-                width: Reader.prototype.getActualReaderWidth(s.Settings.reader, s.$outline)
+                width: Reader.prototype.getActualReaderWidth.call(s.reader, s.Settings.reader, s.$outline)
                 + s.Settings.maincontent.minimizedWidth
                 + ((s.Settings.sidebarEnabled && s.sidebar) ? s.Settings.sidebar.minimizedWidth : 0),
             };

--- a/lib/@uncharted/thumbnails/package.json
+++ b/lib/@uncharted/thumbnails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uncharted/thumbnails",
-  "version": "0.4.33",
+  "version": "0.4.35",
   "description": "Uncharted Software Inc. Thumbnails visual component",
   "main": "dist/uncharted.thumbnails.js",
   "scripts": {
@@ -30,13 +30,13 @@
     "karma-mocha": "^0.2.1",
     "karma-mocha-reporter": "^1.1.5",
     "karma-phantomjs-launcher": "^1.0.0",
-    "karma-sinon-chai": "^1.1.0",
+    "karma-sinon-chai": "^1.3.0",
     "karma-tamtam-bamboo-reporter": "^1.0.1",
     "mocha": "^2.3.4",
     "phantomjs-prebuilt": "^2.1.6",
     "proxyquireify": "^3.0.1",
     "run-sequence": "^1.1.5",
-    "sinon": "^1.17.6",
+    "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0",
     "vinyl-source-stream": "^1.1.0"
   },
@@ -55,7 +55,7 @@
     "underscore": "^1.8.3",
     "font-awesome": "^4.4.0",
     "@uncharted/strippets.common": "0.2.6",
-    "@uncharted/strippets": "0.4.40",
+    "@uncharted/strippets": "0.4.42",
     "handlebars": "^4.0.5",
     "velocity-animate": "^1.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strippetbrowser",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Strippets Browser PowerBI custom visual",
   "main": "src/index.js",
   "scripts": {
@@ -25,8 +25,8 @@
   "privacyTerms": "https://privacy.microsoft.com/en-US/privacystatement/",
   "privateSubmodules": {
     "@uncharted/strippets.common": "0.2.6",
-    "@uncharted/strippets": "0.4.40",
-    "@uncharted/thumbnails": "0.4.33"
+    "@uncharted/strippets": "0.4.42",
+    "@uncharted/thumbnails": "0.4.35"
   },
   "devDependencies": {
     "@types/bluebird": "^3.0.35",


### PR DESCRIPTION
Fix for icons in the expanded view of the strippets and thumbnails icons getting rendered below the document in IE11 and Mobile Safari