### PR TITLE
Fix for symbols appearing below expanded article

### DIFF
--- a/lib/@uncharted/strippets/example/uncharted.strippets.js
+++ b/lib/@uncharted/strippets/example/uncharted.strippets.js
@@ -2301,9 +2301,24 @@ Outline.prototype.resetState = function() {
 Outline.prototype.showEntities = function (display) {
     var s = this;
     if (s.feature && s.feature.$outlineEntityContainer) {
-        s.feature.$outlineEntityContainer.css({
-            display: display,
-        });
+
+        if(display === 'show') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'inline-block',
+                width: '100%',
+            });
+        } else if (display === 'hide') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'none',
+            });
+        } else {
+            s.feature.$outlineEntityContainer.css({
+                display: '',
+                width: '',
+            });
+        }
+
+
     }
 };
 
@@ -2315,7 +2330,7 @@ Outline.prototype.openReadingMode = function() {
     var s = this;
     var promises = [];
 
-    s.showEntities('none');
+    s.showEntities('hide');
 
     promises.push(s.reader.open().then(function() {
         if (!s.readerData) {
@@ -2339,7 +2354,7 @@ Outline.prototype.openReadingMode = function() {
     );
 
     return Promise.all(promises).then(function() {
-        s.showEntities('block');
+        s.showEntities('show');
     });
 };
 
@@ -2365,7 +2380,7 @@ Outline.prototype.loadReadingModeContent = function() {
 Outline.prototype.closeReadingMode = function() {
     var s = this;
     var promises = [];
-    s.showEntities('none');
+    s.showEntities('hide');
     if (s.styles.outlineItem.normal) {
         promises.push(s.$outline.velocity({
             'margin-right': s.styles.outlineItem.normal.getPropertyValue('margin-right'),
@@ -2373,9 +2388,10 @@ Outline.prototype.closeReadingMode = function() {
         }));
     }
     promises.push(s.reader.hide());
-    return Promise.all(promises).then(function () {
-        s.showEntities('block');
+	promises.push(function () {
+        s.showEntities('clear');
     });
+    return Promise.all(promises);
 };
 
 /**
@@ -2480,7 +2496,7 @@ Outline.prototype.getTransitionSizes = function(transitionToState) {
         if (toState === 'readingmode') {
             transitionCompleteSize = {
                 height: s.$outline.height(),
-                width: Reader.prototype.getActualReaderWidth(s.Settings.reader, s.$outline)
+                width: Reader.prototype.getActualReaderWidth.call(s.reader, s.Settings.reader, s.$outline)
                 + s.Settings.maincontent.minimizedWidth
                 + ((s.Settings.sidebarEnabled && s.sidebar) ? s.Settings.sidebar.minimizedWidth : 0),
             };

--- a/lib/@uncharted/strippets/example/uncharted.strippets.js
+++ b/lib/@uncharted/strippets/example/uncharted.strippets.js
@@ -2301,8 +2301,7 @@ Outline.prototype.resetState = function() {
 Outline.prototype.showEntities = function (display) {
     var s = this;
     if (s.feature && s.feature.$outlineEntityContainer) {
-
-        if(display === 'show') {
+        if (display === 'show') {
             s.feature.$outlineEntityContainer.css({
                 display: 'inline-block',
                 width: '100%',
@@ -2317,8 +2316,6 @@ Outline.prototype.showEntities = function (display) {
                 width: '',
             });
         }
-
-
     }
 };
 
@@ -2388,7 +2385,7 @@ Outline.prototype.closeReadingMode = function() {
         }));
     }
     promises.push(s.reader.hide());
-	promises.push(function () {
+    promises.push(function () {
         s.showEntities('clear');
     });
     return Promise.all(promises);
@@ -9434,6 +9431,10 @@ process.off = noop;
 process.removeListener = noop;
 process.removeAllListeners = noop;
 process.emit = noop;
+process.prependListener = noop;
+process.prependOnceListener = noop;
+
+process.listeners = function (name) { return [] }
 
 process.binding = function (name) {
     throw new Error('process.binding is not supported');

--- a/lib/@uncharted/strippets/package.json
+++ b/lib/@uncharted/strippets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uncharted/strippets",
-  "version": "0.4.40",
+  "version": "0.4.42",
   "description": "Uncharted Software Inc. Outlines visual component",
   "main": "src/index.js",
   "scripts": {
@@ -29,13 +29,13 @@
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.1.1",
     "karma-phantomjs-launcher": "^1.0.4",
-    "karma-sinon-chai": "^1.1.0",
+    "karma-sinon-chai": "^1.3.1",
     "karma-tamtam-bamboo-reporter": "^1.0.1",
     "mocha": "^2.3.3",
     "phantomjs-prebuilt": "^2.1.3",
     "proxyquireify": "^3.0.0",
     "run-sequence": "^1.1.5",
-    "sinon": "^1.17.3",
+    "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0",
     "through2": "^2.0.0",
     "vinyl-source-stream": "^1.1.0"

--- a/lib/@uncharted/strippets/package.json
+++ b/lib/@uncharted/strippets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uncharted/strippets",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "description": "Uncharted Software Inc. Outlines visual component",
   "main": "src/index.js",
   "scripts": {

--- a/lib/@uncharted/strippets/src/strippets.outline.js
+++ b/lib/@uncharted/strippets/src/strippets.outline.js
@@ -558,9 +558,24 @@ Outline.prototype.resetState = function() {
 Outline.prototype.showEntities = function (display) {
     var s = this;
     if (s.feature && s.feature.$outlineEntityContainer) {
-        s.feature.$outlineEntityContainer.css({
-            display: display,
-        });
+
+        if(display === 'show') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'inline-block',
+                width: '100%',
+            });
+        } else if (display === 'hide') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'none',
+            });
+        } else {
+            s.feature.$outlineEntityContainer.css({
+                display: '',
+                width: '',
+            });
+        }
+
+
     }
 };
 
@@ -572,7 +587,7 @@ Outline.prototype.openReadingMode = function() {
     var s = this;
     var promises = [];
 
-    s.showEntities('none');
+    s.showEntities('hide');
 
     promises.push(s.reader.open().then(function() {
         if (!s.readerData) {
@@ -596,7 +611,7 @@ Outline.prototype.openReadingMode = function() {
     );
 
     return Promise.all(promises).then(function() {
-        s.showEntities('block');
+        s.showEntities('show');
     });
 };
 
@@ -622,7 +637,7 @@ Outline.prototype.loadReadingModeContent = function() {
 Outline.prototype.closeReadingMode = function() {
     var s = this;
     var promises = [];
-    s.showEntities('none');
+    s.showEntities('hide');
     if (s.styles.outlineItem.normal) {
         promises.push(s.$outline.velocity({
             'margin-right': s.styles.outlineItem.normal.getPropertyValue('margin-right'),
@@ -630,9 +645,10 @@ Outline.prototype.closeReadingMode = function() {
         }));
     }
     promises.push(s.reader.hide());
-    return Promise.all(promises).then(function () {
-        s.showEntities('block');
+	promises.push(function () {
+        s.showEntities('clear');
     });
+    return Promise.all(promises);
 };
 
 /**
@@ -737,7 +753,7 @@ Outline.prototype.getTransitionSizes = function(transitionToState) {
         if (toState === 'readingmode') {
             transitionCompleteSize = {
                 height: s.$outline.height(),
-                width: Reader.prototype.getActualReaderWidth(s.Settings.reader, s.$outline)
+                width: Reader.prototype.getActualReaderWidth.call(s.reader, s.Settings.reader, s.$outline)
                 + s.Settings.maincontent.minimizedWidth
                 + ((s.Settings.sidebarEnabled && s.sidebar) ? s.Settings.sidebar.minimizedWidth : 0),
             };

--- a/lib/@uncharted/strippets/src/strippets.outline.js
+++ b/lib/@uncharted/strippets/src/strippets.outline.js
@@ -558,8 +558,7 @@ Outline.prototype.resetState = function() {
 Outline.prototype.showEntities = function (display) {
     var s = this;
     if (s.feature && s.feature.$outlineEntityContainer) {
-
-        if(display === 'show') {
+        if (display === 'show') {
             s.feature.$outlineEntityContainer.css({
                 display: 'inline-block',
                 width: '100%',
@@ -574,8 +573,6 @@ Outline.prototype.showEntities = function (display) {
                 width: '',
             });
         }
-
-
     }
 };
 
@@ -645,7 +642,7 @@ Outline.prototype.closeReadingMode = function() {
         }));
     }
     promises.push(s.reader.hide());
-	promises.push(function () {
+    promises.push(function () {
         s.showEntities('clear');
     });
     return Promise.all(promises);

--- a/lib/@uncharted/thumbnails/example/uncharted.thumbnails.js
+++ b/lib/@uncharted/thumbnails/example/uncharted.thumbnails.js
@@ -1426,16 +1426,16 @@ var templater = require("handlebars/runtime")["default"].template;module.exports
     var helper;
 
   return "                <h1 class=\"title titleonly\">"
-    + container.escapeExpression(((helper = (helper = helpers.title || (depth0 != null ? depth0.title : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"title","hash":{},"data":data}) : helper)))
+    + container.escapeExpression(((helper = (helper = helpers.title || (depth0 != null ? depth0.title : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"title","hash":{},"data":data}) : helper)))
     + "</h1>\n";
 },"5":function(container,depth0,helpers,partials,data) {
     var helper;
 
   return "                <h1 class=\"title\">"
-    + container.escapeExpression(((helper = (helper = helpers.title || (depth0 != null ? depth0.title : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : {},{"name":"title","hash":{},"data":data}) : helper)))
+    + container.escapeExpression(((helper = (helper = helpers.title || (depth0 != null ? depth0.title : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"title","hash":{},"data":data}) : helper)))
     + "</h1>\n";
 },"7":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "                    <li>\n                        <time class=\"updated\" datetime=\""
     + alias4(((helper = (helper = helpers.articledate || (depth0 != null ? depth0.articledate : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"articledate","hash":{},"data":data}) : helper)))
@@ -1443,7 +1443,7 @@ var templater = require("handlebars/runtime")["default"].template;module.exports
     + alias4(((helper = (helper = helpers.formattedDate || (depth0 != null ? depth0.formattedDate : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"formattedDate","hash":{},"data":data}) : helper)))
     + "</time>\n                    </li>\n";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "<div class=\"thumbnail\" data-id=\""
     + alias4(((helper = (helper = helpers.id || (depth0 != null ? depth0.id : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"id","hash":{},"data":data}) : helper)))
@@ -5313,8 +5313,7 @@ Outline.prototype.resetState = function() {
 Outline.prototype.showEntities = function (display) {
     var s = this;
     if (s.feature && s.feature.$outlineEntityContainer) {
-
-        if(display === 'show') {
+        if (display === 'show') {
             s.feature.$outlineEntityContainer.css({
                 display: 'inline-block',
                 width: '100%',
@@ -5329,8 +5328,6 @@ Outline.prototype.showEntities = function (display) {
                 width: '',
             });
         }
-
-
     }
 };
 
@@ -5400,7 +5397,7 @@ Outline.prototype.closeReadingMode = function() {
         }));
     }
     promises.push(s.reader.hide());
-	promises.push(function () {
+    promises.push(function () {
         s.showEntities('clear');
     });
     return Promise.all(promises);
@@ -11771,6 +11768,10 @@ process.off = noop;
 process.removeListener = noop;
 process.removeAllListeners = noop;
 process.emit = noop;
+process.prependListener = noop;
+process.prependOnceListener = noop;
+
+process.listeners = function (name) { return [] }
 
 process.binding = function (name) {
     throw new Error('process.binding is not supported');
@@ -11873,7 +11874,7 @@ var _logger = require('./logger');
 
 var _logger2 = _interopRequireDefault(_logger);
 
-var VERSION = '4.0.5';
+var VERSION = '4.0.7';
 exports.VERSION = VERSION;
 var COMPILER_REVISION = 7;
 
@@ -12042,7 +12043,10 @@ function Exception(message, node) {
       // Work around issue under safari where we can't directly set the column value
       /* istanbul ignore next */
       if (Object.defineProperty) {
-        Object.defineProperty(this, 'column', { value: column });
+        Object.defineProperty(this, 'column', {
+          value: column,
+          enumerable: true
+        });
       } else {
         this.column = column;
       }
@@ -12599,6 +12603,8 @@ function template(templateSpec, env) {
 
       return obj;
     },
+    // An empty object to use as replacement for null-contexts
+    nullContext: Object.seal({}),
 
     noop: env.VM.noop,
     compilerInfo: templateSpec.compiler
@@ -12666,7 +12672,7 @@ function wrapProgram(container, i, fn, data, declaredBlockParams, blockParams, d
     var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
     var currentDepths = depths;
-    if (depths && context != depths[0]) {
+    if (depths && context != depths[0] && !(context === container.nullContext && depths[0] === null)) {
       currentDepths = [context].concat(depths);
     }
 
@@ -12684,12 +12690,7 @@ function wrapProgram(container, i, fn, data, declaredBlockParams, blockParams, d
 function resolvePartial(partial, context, options) {
   if (!partial) {
     if (options.name === '@partial-block') {
-      var data = options.data;
-      while (data['partial-block'] === noop) {
-        data = data._parent;
-      }
-      partial = data['partial-block'];
-      data['partial-block'] = noop;
+      partial = options.data['partial-block'];
     } else {
       partial = options.partials[options.name];
     }
@@ -12702,6 +12703,8 @@ function resolvePartial(partial, context, options) {
 }
 
 function invokePartial(partial, context, options) {
+  // Use the current closure context to save the partial-block if this partial
+  var currentPartialBlock = options.data && options.data['partial-block'];
   options.partial = true;
   if (options.ids) {
     options.data.contextPath = options.ids[0] || options.data.contextPath;
@@ -12709,12 +12712,21 @@ function invokePartial(partial, context, options) {
 
   var partialBlock = undefined;
   if (options.fn && options.fn !== noop) {
-    options.data = _base.createFrame(options.data);
-    partialBlock = options.data['partial-block'] = options.fn;
-
-    if (partialBlock.partials) {
-      options.partials = Utils.extend({}, options.partials, partialBlock.partials);
-    }
+    (function () {
+      options.data = _base.createFrame(options.data);
+      // Wrapper function to get access to currentPartialBlock from the closure
+      var fn = options.fn;
+      partialBlock = options.data['partial-block'] = function partialBlockWrapper(context, options) {
+        // Restore the partial-block from the closure for the execution of the block
+        // i.e. the part inside the block of the partial call.
+        options.data = _base.createFrame(options.data);
+        options.data['partial-block'] = currentPartialBlock;
+        return fn(context, options);
+      };
+      if (fn.partials) {
+        options.partials = Utils.extend({}, options.partials, fn.partials);
+      }
+    })();
   }
 
   if (partial === undefined && partialBlock) {

--- a/lib/@uncharted/thumbnails/example/uncharted.thumbnails.js
+++ b/lib/@uncharted/thumbnails/example/uncharted.thumbnails.js
@@ -5313,9 +5313,24 @@ Outline.prototype.resetState = function() {
 Outline.prototype.showEntities = function (display) {
     var s = this;
     if (s.feature && s.feature.$outlineEntityContainer) {
-        s.feature.$outlineEntityContainer.css({
-            display: display,
-        });
+
+        if(display === 'show') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'inline-block',
+                width: '100%',
+            });
+        } else if (display === 'hide') {
+            s.feature.$outlineEntityContainer.css({
+                display: 'none',
+            });
+        } else {
+            s.feature.$outlineEntityContainer.css({
+                display: '',
+                width: '',
+            });
+        }
+
+
     }
 };
 
@@ -5327,7 +5342,7 @@ Outline.prototype.openReadingMode = function() {
     var s = this;
     var promises = [];
 
-    s.showEntities('none');
+    s.showEntities('hide');
 
     promises.push(s.reader.open().then(function() {
         if (!s.readerData) {
@@ -5351,7 +5366,7 @@ Outline.prototype.openReadingMode = function() {
     );
 
     return Promise.all(promises).then(function() {
-        s.showEntities('block');
+        s.showEntities('show');
     });
 };
 
@@ -5377,7 +5392,7 @@ Outline.prototype.loadReadingModeContent = function() {
 Outline.prototype.closeReadingMode = function() {
     var s = this;
     var promises = [];
-    s.showEntities('none');
+    s.showEntities('hide');
     if (s.styles.outlineItem.normal) {
         promises.push(s.$outline.velocity({
             'margin-right': s.styles.outlineItem.normal.getPropertyValue('margin-right'),
@@ -5385,9 +5400,10 @@ Outline.prototype.closeReadingMode = function() {
         }));
     }
     promises.push(s.reader.hide());
-    return Promise.all(promises).then(function () {
-        s.showEntities('block');
+	promises.push(function () {
+        s.showEntities('clear');
     });
+    return Promise.all(promises);
 };
 
 /**
@@ -5492,7 +5508,7 @@ Outline.prototype.getTransitionSizes = function(transitionToState) {
         if (toState === 'readingmode') {
             transitionCompleteSize = {
                 height: s.$outline.height(),
-                width: Reader.prototype.getActualReaderWidth(s.Settings.reader, s.$outline)
+                width: Reader.prototype.getActualReaderWidth.call(s.reader, s.Settings.reader, s.$outline)
                 + s.Settings.maincontent.minimizedWidth
                 + ((s.Settings.sidebarEnabled && s.sidebar) ? s.Settings.sidebar.minimizedWidth : 0),
             };

--- a/lib/@uncharted/thumbnails/package.json
+++ b/lib/@uncharted/thumbnails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uncharted/thumbnails",
-  "version": "0.4.33",
+  "version": "0.4.35",
   "description": "Uncharted Software Inc. Thumbnails visual component",
   "main": "dist/uncharted.thumbnails.js",
   "scripts": {
@@ -30,13 +30,13 @@
     "karma-mocha": "^0.2.1",
     "karma-mocha-reporter": "^1.1.5",
     "karma-phantomjs-launcher": "^1.0.0",
-    "karma-sinon-chai": "^1.1.0",
+    "karma-sinon-chai": "^1.3.0",
     "karma-tamtam-bamboo-reporter": "^1.0.1",
     "mocha": "^2.3.4",
     "phantomjs-prebuilt": "^2.1.6",
     "proxyquireify": "^3.0.1",
     "run-sequence": "^1.1.5",
-    "sinon": "^1.17.6",
+    "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0",
     "vinyl-source-stream": "^1.1.0"
   },
@@ -55,7 +55,7 @@
     "underscore": "^1.8.3",
     "font-awesome": "^4.4.0",
     "@uncharted/strippets.common": "0.2.6",
-    "@uncharted/strippets": "0.4.40",
+    "@uncharted/strippets": "0.4.42",
     "handlebars": "^4.0.5",
     "velocity-animate": "^1.5.0"
   },

--- a/lib/@uncharted/thumbnails/package.json
+++ b/lib/@uncharted/thumbnails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uncharted/thumbnails",
-  "version": "0.4.35",
+  "version": "0.4.36",
   "description": "Uncharted Software Inc. Thumbnails visual component",
   "main": "dist/uncharted.thumbnails.js",
   "scripts": {
@@ -55,7 +55,7 @@
     "underscore": "^1.8.3",
     "font-awesome": "^4.4.0",
     "@uncharted/strippets.common": "0.2.6",
-    "@uncharted/strippets": "0.4.42",
+    "@uncharted/strippets": "0.4.43",
     "handlebars": "^4.0.5",
     "velocity-animate": "^1.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "privacyTerms": "https://privacy.microsoft.com/en-US/privacystatement/",
   "privateSubmodules": {
     "@uncharted/strippets.common": "0.2.6",
-    "@uncharted/strippets": "0.4.42",
-    "@uncharted/thumbnails": "0.4.35"
+    "@uncharted/strippets": "0.4.43",
+    "@uncharted/thumbnails": "0.4.36"
   },
   "devDependencies": {
     "@types/bluebird": "^3.0.35",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strippetbrowser",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Strippets Browser PowerBI custom visual",
   "main": "src/index.js",
   "scripts": {
@@ -25,8 +25,8 @@
   "privacyTerms": "https://privacy.microsoft.com/en-US/privacystatement/",
   "privateSubmodules": {
     "@uncharted/strippets.common": "0.2.6",
-    "@uncharted/strippets": "0.4.40",
-    "@uncharted/thumbnails": "0.4.33"
+    "@uncharted/strippets": "0.4.42",
+    "@uncharted/thumbnails": "0.4.35"
   },
   "devDependencies": {
     "@types/bluebird": "^3.0.35",


### PR DESCRIPTION
Fixed problem where in IOS and IE11, expanding an article would cause the symbols to appear below the article.