### PR TITLE
Fixed wrong type verifying during build

### DIFF
--- a/src/StrippetsVisual.ts
+++ b/src/StrippetsVisual.ts
@@ -893,7 +893,7 @@ export default class StrippetBrowser16424341054522 implements IVisual {
             entityMap = _.toArray(entityMap).sort(function (a: MappedEntity, b: MappedEntity) {
                 return b.text.length - a.text.length;
             });
-            _.each(entityMap, function (entity) {
+            _.each(entityMap, function (entity: MappedEntity) {
                 let textNodes = [];
 
                 // used by the NodeFilter above


### PR DESCRIPTION
Hi Guys, I wasn't able to build package without this fix. I always had errors, something like that:
"Property 'text' does not exist on type 'string'."
"Property 'key' does not exist on type 'string'." and etc.

This fix helped to me build package